### PR TITLE
dynamically check if the dbt_observability:objects variable is in use

### DIFF
--- a/models/sources/all_executions.sql
+++ b/models/sources/all_executions.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='all_executions')) %}
 {% endfor %}

--- a/models/sources/columns.sql
+++ b/models/sources/columns.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='columns')) %}
 {% endfor %}

--- a/models/sources/exposures.sql
+++ b/models/sources/exposures.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='exposures')) %}
 {% endfor %}

--- a/models/sources/invocations.sql
+++ b/models/sources/invocations.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='invocations')) %}
 {% endfor %}

--- a/models/sources/metrics.sql
+++ b/models/sources/metrics.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='metrics')) %}
 {% endfor %}

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='models')) %}
 {% endfor %}

--- a/models/sources/seeds.sql
+++ b/models/sources/seeds.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='seeds')) %}
 {% endfor %}

--- a/models/sources/snapshots.sql
+++ b/models/sources/snapshots.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='snapshots')) %}
 {% endfor %}

--- a/models/sources/sources.sql
+++ b/models/sources/sources.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='sources')) %}
 {% endfor %}

--- a/models/sources/tests.sql
+++ b/models/sources/tests.sql
@@ -1,6 +1,12 @@
+{% set build_union = (var('dbt_observability:objects', none) is not none) %}
+{{
+    config(
+        enabled=build_union
+    )
+}}
 {% set relations = [] %}
-{% for database in var('dbt_observability:objects') %}
-{% for schema in var('dbt_observability:objects')[database] %}
+{% for database in var('dbt_observability:objects', '') %}
+{% for schema in var('dbt_observability:objects', '')[database] %}
 
 {% do relations.append(api.Relation.create(database=database, schema=schema, identifier='tests')) %}
 {% endfor %}

--- a/models/staging/stg_column.sql
+++ b/models/staging/stg_column.sql
@@ -3,6 +3,9 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
+
 select
     command_invocation_id,
     node_id,
@@ -22,4 +25,9 @@ select
     row_stdev,
     is_metric,
     column_values
-from {{ ref('columns') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'columns') }}
+{% else %}
+from {{ ref('dbt_observability', 'columns') }}
+{% endif %}
+

--- a/models/staging/stg_execution.sql
+++ b/models/staging/stg_execution.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -17,4 +18,9 @@ select
     schema_name,
     name,
     resource_type
-from {{ ref('all_executions') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'all_executions') }}
+{% else %}
+from {{ ref('dbt_observability', 'all_executions') }}
+{% endif %}
+

--- a/models/staging/stg_exposure.sql
+++ b/models/staging/stg_exposure.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -16,4 +17,9 @@ select
     url,
     package_name,
     depends_on_nodes
-from {{ ref('exposures') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'exposures') }}
+{% else %}
+from {{ ref('dbt_observability', 'exposures') }}
+{% endif %}
+

--- a/models/staging/stg_invocation.sql
+++ b/models/staging/stg_invocation.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     dbt_version,
@@ -22,4 +23,9 @@ select
     dbt_cloud_run_reason,
     env_vars,
     dbt_vars
-from {{ ref('invocations') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'invocations') }}
+{% else %}
+from {{ ref('dbt_observability', 'invocations') }}
+{% endif %}
+

--- a/models/staging/stg_metric.sql
+++ b/models/staging/stg_metric.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     unique_id,
@@ -18,4 +19,9 @@ select
     meta,
     depends_on_nodes,
     description
-from {{ ref('metrics') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'metrics') }}
+{% else %}
+from {{ ref('dbt_observability', 'metrics') }}
+{% endif %}
+

--- a/models/staging/stg_model.sql
+++ b/models/staging/stg_model.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -19,4 +20,9 @@ select
     meta,
     description,
     total_rowcount
-from {{ ref('models') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'models') }}
+{% else %}
+from {{ ref('dbt_observability', 'models') }}
+{% endif %}
+

--- a/models/staging/stg_seed.sql
+++ b/models/staging/stg_seed.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -13,4 +14,9 @@ select
     package_name,
     path,
     checksum
-from {{ ref('seeds') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'seeds') }}
+{% else %}
+from {{ ref('dbt_observability', 'seeds') }}
+{% endif %}
+

--- a/models/staging/stg_snapshot.sql
+++ b/models/staging/stg_snapshot.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -15,4 +16,9 @@ select
     path,
     checksum,
     strategy
-from {{ ref('snapshots') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'snapshots') }}
+{% else %}
+from {{ ref('dbt_observability', 'snapshots') }}
+{% endif %}
+

--- a/models/staging/stg_source.sql
+++ b/models/staging/stg_source.sql
@@ -3,6 +3,15 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+
+{% if (var('dbt_observability:objects', none) is not none) %}
+    {% set target_name = 'dbt_observability_marts' %}
+{% else %}
+    {% set target_name = 'dbt_observability' %}
+{% endif %}
+
+{% set column_names = dbt_utils.get_filtered_columns_in_relation(from=ref(target_name, 'sources')) %}
+
 select
     command_invocation_id,
     node_id,
@@ -15,5 +24,9 @@ select
     identifier,
     loaded_at_field,
     freshness,
+    {# total_rowcount is a new feature, so we check its existence before selecting it for backwards compatibility #}
+    {% if 'total_rowcount' not in column_names | lower %}
+    0 as
+    {% endif %}
     total_rowcount
-from {{ ref('sources') }}
+from {{ ref(target_name, 'sources') }}

--- a/models/staging/stg_test.sql
+++ b/models/staging/stg_test.sql
@@ -3,6 +3,7 @@
         enabled=var('dbt_observability:marts_enabled', true)
     )
 }}
+{% set ref_union = (var('dbt_observability:objects', none) is not none) %}
 select
     command_invocation_id,
     node_id,
@@ -13,4 +14,9 @@ select
     test_path,
     tags,
     test_metadata
-from {{ ref('tests') }}
+{% if ref_union %}
+from {{ ref('dbt_observability_marts', 'tests') }}
+{% else %}
+from {{ ref('dbt_observability', 'tests') }}
+{% endif %}
+


### PR DESCRIPTION
This PR updates the source and staging layer to check if the `dbt_observability:objects` variable is in use.
sources are disabled if the variable is not in use
staging selects from the `dbt_observability` models if the variable is not in use