### PR TITLE
update `len` syntax to use universal dbt length

### DIFF
--- a/models/reporting/schema_changes.sql
+++ b/models/reporting/schema_changes.sql
@@ -108,7 +108,11 @@ added as (
         null as precise_data_type,
         null as precise_pre_data_type,
         {{ dbt.concat(['resource_type', "'_added'"]) }} as change_type,
-        {{ dbt.concat(["upper(substring(resource_type, 1, 1))", "lower(substring(resource_type, 2, len(resource_type)))", "' Added'"]) }} as change_type_desc,
+        {{ dbt.concat([
+            "upper(substring(resource_type, 1, 1))",
+            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+            "' Added'"
+        ]) }} as change_type_desc,
         run_started_at as detected_at
     from
         executions
@@ -131,7 +135,11 @@ first_observed as (
         null as precise_data_type,
         null as precise_pre_data_type,
         {{ dbt.concat(['resource_type', "'_first_observed'"]) }} as change_type,
-        {{ dbt.concat(["upper(substring(resource_type, 1, 1))", "lower(substring(resource_type, 2, len(resource_type)))", "' First Observed'"]) }} as change_type_desc,
+        {{ dbt.concat([
+            "upper(substring(resource_type, 1, 1))",
+            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+            "' First Observed'"
+        ]) }} as change_type_desc,
         run_started_at as detected_at
     from
         executions
@@ -154,9 +162,13 @@ removed as (
         null as generic_pre_data_type,
         null as precise_data_type,
         null as precise_pre_data_type,
-        run_started_at as detected_at,
         {{ dbt.concat(['resource_type', "'_removed'"]) }} as change_type,
-        {{ dbt.concat(["upper(substring(resource_type, 1, 1))", "lower(substring(resource_type, 2, len(resource_type)))", "' Removed'"]) }} as change_type_desc
+        {{ dbt.concat([
+            "upper(substring(resource_type, 1, 1))",
+            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+            "' Removed'"
+        ]) }} as change_type_desc,
+        run_started_at as detected_at
     from
         executions
     where


### PR DESCRIPTION
This PR updates `schema_changes` to use [dbt.length](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#length) instead of `len` for more universal adapter support