### PR TITLE
partition by project_id when calculating most_recent_run

### DIFF
--- a/models/marts/dim_execution.sql
+++ b/models/marts/dim_execution.sql
@@ -19,7 +19,7 @@ with
             thread_id,
             compile_started_at,
             query_completed_at,
-            rank() over (order by run_started_at desc) as run_rank,
+            rank() over (partition by project order by run_started_at desc) as run_rank,
             rank() over (partition by node_id order by run_started_at desc) as node_rank,
             rank() over (partition by node_id, cast(run_started_at as date) order by run_started_at desc) as node_rank_per_day
         from {{ ref('dbt_observability_marts', 'int_execution') }}

--- a/models/marts/dim_invocation.sql
+++ b/models/marts/dim_invocation.sql
@@ -24,9 +24,9 @@ with
             env_vars,
             dbt_vars,
             run_started_at,
-            rank() over (order by run_started_at desc) as invocation_rank,
+            rank() over (partition by project_name order by run_started_at desc) as invocation_rank,
             rank() over (
-                partition by cast(run_started_at as date)
+                partition by project_name, cast(run_started_at as date)
                 order by run_started_at desc
                 ) as invocation_rank_per_day
         from {{ ref('dbt_observability_marts', 'stg_invocation') }}

--- a/models/marts/dim_invocation.yml
+++ b/models/marts/dim_invocation.yml
@@ -27,7 +27,7 @@ models:
         meta:
           label: Invocation Order
       - name: most_recent_run
-        description: '"Yes" if this is the most recent invocation for all time, otherwise "No"'
+        description: '"Yes" if this is the most recent invocation for all time, partitioned by project, otherwise "No"'
         meta:
           label: Most Recent Run
       - name: invocation_rank_per_day


### PR DESCRIPTION
This PR adds logic to partition by project when calculating `most_recent_run` in order to ensure the logic works for those using this package to union multiple projects together. 