### PR TITLE
Data type improvements

### DIFF
--- a/models/intermediate/int_execution.sql
+++ b/models/intermediate/int_execution.sql
@@ -22,7 +22,7 @@ select
     materialization,
     schema_name
 from {{ ref('dbt_observability_marts', 'stg_execution') }}
-union
+union all
 select
     command_invocation_id,
     node_id,

--- a/models/marts/dim_column.sql
+++ b/models/marts/dim_column.sql
@@ -19,7 +19,7 @@ with
         from {{ ref('dbt_observability_marts', 'int_column') }}
     )
 
-select distinct
+select
     {{ dbt_utils.generate_surrogate_key(['command_invocation_id', 'node_id', 'column_name']) }} as column_key,
     node_id,
     resource_type,

--- a/models/marts/dim_column.sql
+++ b/models/marts/dim_column.sql
@@ -14,12 +14,18 @@ with
             column_name,
             data_type,
             tags,
-            meta,
+            {% if target.type == 'bigquery' %}
+                TO_JSON_STRING(meta) as meta,
+            {% elif target.type == 'snowflake' %}
+                TO_JSON(meta) as meta,
+            {% else %} 
+                meta,
+            {% endif %}
             description
         from {{ ref('dbt_observability_marts', 'int_column') }}
     )
 
-select
+select distinct
     {{ dbt_utils.generate_surrogate_key(['command_invocation_id', 'node_id', 'column_name']) }} as column_key,
     node_id,
     resource_type,

--- a/models/marts/dim_model.sql
+++ b/models/marts/dim_model.sql
@@ -4,80 +4,80 @@
     )
 }}
 with
-models as (
-    select
+    models as (
+        select
             {{ dbt_utils.generate_surrogate_key([
                 'command_invocation_id', 'node_id'
                 ]) }} as model_key,
-        node_id,
-        run_started_at,
-        resource_type,
-        project,
-        resource_name,
-        database_name,
-        schema_name,
-        name,
-        package_name,
-        path,
-        checksum,
-        materialization,
-        tags,
-        meta,
-        description
-    from {{ ref('dbt_observability_marts', 'int_model') }}
-),
+            node_id,
+            run_started_at,
+            resource_type,
+            project,
+            resource_name,
+            database_name,
+            schema_name,
+            name,
+            package_name,
+            path,
+            checksum,
+            materialization,
+            tags,
+            meta,
+            description
+        from {{ ref('dbt_observability_marts', 'int_model') }}
+    ),
 
-_tests as (
-    select
-        lower(
-            {% if target.type == 'snowflake' %}
-                array_to_string(depends_on_nodes, '')
-            {% else %}
+    _tests as (
+        select
+            lower(
+                {% if target.type in ('snowflake', 'bigquery') %}
+                    array_to_string(depends_on_nodes, '')
+                {% else %}
                 depends_on_nodes
             {% endif %})
-            as depends_on_nodes
-    from {{ ref('dbt_observability_marts', 'stg_test') }}
-),
+                as depends_on_nodes
+        from {{ ref('dbt_observability_marts', 'stg_test') }}
+    ),
 
-_models as (
-    select
-        node_id,
-        model_key,
-        {{ dbt.concat(["'%'", 'lower(node_id)', "'%'"]) }} as node_key
-    from models
-),
+    _models as (
+        select
+            node_id,
+            model_key,
+            {{ dbt.concat(["'%'", 'lower(node_id)', "'%'"]) }} as node_key
+        from models
+    ),
 
-untested_models as (
-    select distinct models.model_key
-    from _models as models
-    left outer join _tests as test
-        on test.depends_on_nodes like models.node_key
-    where test.depends_on_nodes is null
-),
+    untested_models as (
+        select distinct models.model_key
+        from _models as models
+        left outer join _tests as test
+            on test.depends_on_nodes like models.node_key
+        where test.depends_on_nodes is null
+    ),
 
-final as (
-    select
-        models.model_key,
-        models.node_id,
-        models.resource_type,
-        models.project,
-        models.resource_name,
-        models.database_name,
-        models.schema_name,
-        models.name,
-        models.package_name,
-        models.path,
-        models.checksum,
-        models.materialization,
-        models.tags,
-        models.meta,
-        models.description,
-        case when untested_models.model_key is null then 'Yes' else 'No' end
-            as is_tested
-    from models
-    left outer join
-        untested_models
-        on models.model_key = untested_models.model_key
-)
+    final as (
+        select
+            models.model_key,
+            models.node_id,
+            models.resource_type,
+            models.project,
+            models.resource_name,
+            models.database_name,
+            models.schema_name,
+            models.name,
+            models.package_name,
+            models.path,
+            models.checksum,
+            models.materialization,
+            models.tags,
+            models.meta,
+            models.description,
+            case when untested_models.model_key is null then 'Yes' else 'No' end
+                as is_tested
+        from models
+        left outer join
+            untested_models
+            on models.model_key = untested_models.model_key
+    )
 
 select * from final

--- a/models/reporting/schema_changes.sql
+++ b/models/reporting/schema_changes.sql
@@ -5,396 +5,404 @@
 }}
 with
 
-executions as (
-    select
-        command_invocation_id,
-        run_started_at,
-        node_id,
-        resource_type,
-        project,
-        resource_name,
-        min(run_started_at) over () as project_first_run_started_at,
-        max(run_started_at)
-            over ()
-            as project_most_recent_run_started_at,
-        min(run_started_at)
-            over (partition by node_id)
-            as node_first_run_started_at,
-        max(run_started_at)
-            over (partition by node_id)
-            as node_most_recent_run_started_at,
-        lag(run_started_at)
-            over (partition by node_id order by run_started_at)
-            as previous_run_started_at,
-        lead(run_started_at)
-            over (partition by node_id order by run_started_at)
-            as next_run_started_at
-    from {{ ref('dbt_observability_marts', 'int_execution') }}
-),
+    executions as (
+        select
+            command_invocation_id,
+            run_started_at,
+            node_id,
+            resource_type,
+            project,
+            resource_name,
+            min(run_started_at) over () as project_first_run_started_at,
+            max(run_started_at)
+                over ()
+                as project_most_recent_run_started_at,
+            min(run_started_at)
+                over (partition by node_id)
+                as node_first_run_started_at,
+            max(run_started_at)
+                over (partition by node_id)
+                as node_most_recent_run_started_at,
+            lag(run_started_at)
+                over (
+                    partition by node_id
+                    order by run_started_at
+                )
+                as previous_run_started_at,
+            lead(run_started_at)
+                over (
+                    partition by node_id
+                    order by run_started_at
+                )
+                as next_run_started_at
+        from {{ ref('dbt_observability_marts', 'int_execution') }}
+    ),
 
-_raw_columns as (
-    select distinct
-        cols.node_id,
-        cols.command_invocation_id,
-        cols.column_name,
-        cols.data_type as raw_data_type,
-        excs.resource_type,
-        excs.project,
-        excs.resource_name,
-        excs.run_started_at,
-        min(excs.run_started_at)
-            over (partition by cols.node_id)
-            as node_first_run_started_at,
-        max(excs.run_started_at)
-            over (partition by cols.node_id)
-            as node_most_recent_run_started_at,
-        lag(excs.run_started_at)
-            over (
-                partition by cols.node_id, cols.column_name
-                order by excs.run_started_at
-            )
-            as column_previous_run_started_at,
-        lead(excs.run_started_at)
-            over (
-                partition by cols.node_id, cols.column_name
-                order by excs.run_started_at
-            )
-            as column_next_run_started_at,
-        lag(cols.data_type)
-            over (
-                partition by cols.node_id, cols.column_name
-                order by excs.run_started_at
-            )
-            as raw_pre_data_type
-    from {{ ref('dbt_observability_marts', 'stg_column') }} as cols
-    inner join executions
-        as excs on cols.command_invocation_id = excs.command_invocation_id
-    and cols.node_id = excs.node_id
-),
+    _raw_columns as (
+        select distinct
+            cols.node_id,
+            cols.command_invocation_id,
+            cols.column_name,
+            cols.data_type as raw_data_type,
+            excs.resource_type,
+            excs.project,
+            excs.resource_name,
+            excs.run_started_at,
+            min(excs.run_started_at)
+                over (partition by cols.node_id)
+                as node_first_run_started_at,
+            max(excs.run_started_at)
+                over (partition by cols.node_id)
+                as node_most_recent_run_started_at,
+            lag(excs.run_started_at)
+                over (
+                    partition by cols.node_id, cols.column_name
+                    order by excs.run_started_at
+                )
+                as column_previous_run_started_at,
+            lead(excs.run_started_at)
+                over (
+                    partition by cols.node_id, cols.column_name
+                    order by excs.run_started_at
+                )
+                as column_next_run_started_at,
+            lag(cols.data_type)
+                over (
+                    partition by cols.node_id, cols.column_name
+                    order by excs.run_started_at
+                )
+                as raw_pre_data_type
+        from {{ ref('dbt_observability_marts', 'stg_column') }} as cols
+        inner join executions
+            as excs on cols.command_invocation_id = excs.command_invocation_id
+            and cols.node_id = excs.node_id
+    ),
 
-columns as (
-    select
-        node_id,
-        command_invocation_id,
-        column_name,
-        {{ convert_to_generic_type('raw_data_type') }} as generic_data_type,
-        {{ convert_to_generic_type('raw_pre_data_type') }}
-            as generic_pre_data_type,
-        raw_data_type as precise_data_type,
-        raw_pre_data_type as precise_pre_data_type,
-        resource_type,
-        project,
-        resource_name,
-        run_started_at,
-        node_first_run_started_at,
-        node_most_recent_run_started_at,
-        column_previous_run_started_at,
-        column_next_run_started_at
-    from _raw_columns
-),
+    columns as (
+        select
+            node_id,
+            command_invocation_id,
+            column_name,
+            {{ convert_to_generic_type('raw_data_type') }} as generic_data_type,
+            {{ convert_to_generic_type('raw_pre_data_type') }}
+                as generic_pre_data_type,
+            raw_data_type as precise_data_type,
+            raw_pre_data_type as precise_pre_data_type,
+            resource_type,
+            project,
+            resource_name,
+            run_started_at,
+            node_first_run_started_at,
+            node_most_recent_run_started_at,
+            column_previous_run_started_at,
+            column_next_run_started_at
+        from _raw_columns
+    ),
 
--- models, seeds, snapshots, tests, and sources
-added as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        run_started_at,
-        null as column_name,
-        null as generic_data_type,
-        null as generic_pre_data_type,
-        null as precise_data_type,
-        null as precise_pre_data_type,
-        {{ dbt.concat(['resource_type', "'_added'"]) }} as change_type,
-        {{ dbt.concat([
-            "upper(substring(resource_type, 1, 1))",
-            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
-            "' Added'"
-        ]) }} as change_type_desc,
-        run_started_at as detected_at
-    from
-        executions
-    where
-        previous_run_started_at is null
-        and run_started_at > project_first_run_started_at
-),
+    -- models, seeds, snapshots, tests, and sources
+    added as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            run_started_at,
+            '' as column_name,
+            '' as generic_data_type,
+            '' as generic_pre_data_type,
+            '' as precise_data_type,
+            '' as precise_pre_data_type,
+            {{ dbt.concat(['resource_type', "'_added'"]) }} as change_type,
+            {{ dbt.concat([
+                "upper(substring(resource_type, 1, 1))",
+                "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+                "' Added'"
+            ]) }} as change_type_desc,
+            run_started_at as detected_at
+        from
+            executions
+        where
+            previous_run_started_at is null
+            and run_started_at > project_first_run_started_at
+    ),
 
-first_observed as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        run_started_at,
-        null as column_name,
-        null as generic_data_type,
-        null as generic_pre_data_type,
-        null as precise_data_type,
-        null as precise_pre_data_type,
-        {{ dbt.concat(['resource_type', "'_first_observed'"]) }} as change_type,
-        {{ dbt.concat([
-            "upper(substring(resource_type, 1, 1))",
-            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
-            "' First Observed'"
-        ]) }} as change_type_desc,
-        run_started_at as detected_at
-    from
-        executions
-    where
-        previous_run_started_at is null
-        and run_started_at = project_first_run_started_at
-),
-
-
-removed as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        run_started_at,
-        null as column_name,
-        null as generic_data_type,
-        null as generic_pre_data_type,
-        null as precise_data_type,
-        null as precise_pre_data_type,
-        {{ dbt.concat(['resource_type', "'_removed'"]) }} as change_type,
-        {{ dbt.concat([
-            "upper(substring(resource_type, 1, 1))",
-            "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
-            "' Removed'"
-        ]) }} as change_type_desc,
-        run_started_at as detected_at
-    from
-        executions
-    where
-        next_run_started_at is null
-        and run_started_at < node_most_recent_run_started_at
-        and run_started_at < project_most_recent_run_started_at
-),
-
--- columns
-columns_added as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        'column_added' as change_type,
-        'Column Added' as change_type_desc,
-        run_started_at,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        run_started_at as detected_at
-    from columns
-    where
-        column_previous_run_started_at is null
-        and run_started_at > node_first_run_started_at
-),
-
-columns_first_observed as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        'column_first_observed' as change_type,
-        'Column First Observed' as change_type_desc,
-        run_started_at,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        run_started_at as detected_at
-    from columns
-    where
-        column_previous_run_started_at is null
-        and run_started_at = node_first_run_started_at
-),
+    first_observed as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            run_started_at,
+            '' as column_name,
+            '' as generic_data_type,
+            '' as generic_pre_data_type,
+            '' as precise_data_type,
+            '' as precise_pre_data_type,
+            {{ dbt.concat(['resource_type', "'_first_observed'"]) }} as change_type,
+            {{ dbt.concat([
+                "upper(substring(resource_type, 1, 1))",
+                "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+                "' First Observed'"
+            ]) }} as change_type_desc,
+            run_started_at as detected_at
+        from
+            executions
+        where
+            previous_run_started_at is null
+            and run_started_at = project_first_run_started_at
+    ),
 
 
-columns_removed as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        'column_removed' as change_type,
-        'Column Removed' as change_type_desc,
-        run_started_at,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        run_started_at as detected_at
-    from columns
-    where
-        column_next_run_started_at is null
-        and run_started_at < node_most_recent_run_started_at
-),
+    removed as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            run_started_at,
+            '' as column_name,
+            '' as generic_data_type,
+            '' as generic_pre_data_type,
+            '' as precise_data_type,
+            '' as precise_pre_data_type,
+            {{ dbt.concat(['resource_type', "'_removed'"]) }} as change_type,
+            {{ dbt.concat([
+                "upper(substring(resource_type, 1, 1))",
+                "lower(substring(resource_type, 2, " ~ dbt.length('resource_type') ~ "))",
+                "' Removed'"
+            ]) }} as change_type_desc,
+            run_started_at as detected_at
+        from
+            executions
+        where
+            next_run_started_at is null
+            and run_started_at < node_most_recent_run_started_at
+            and run_started_at < project_most_recent_run_started_at
+    ),
 
--- type changes
-type_changes as (
-    select
-        node_id,
-        command_invocation_id,
-        'column' as resource_type,
-        project,
-        resource_name,
-        'type_changed' as change_type,
-        'Type Changed' as change_type_desc,
-        run_started_at,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        run_started_at as detected_at
-    from columns where generic_data_type != generic_pre_data_type
-    union
-    select
-        node_id,
-        command_invocation_id,
-        'column' as resource_type,
-        project,
-        resource_name,
-        'precision_changed' as change_type,
-        'Precision Changed' as change_type_desc,
-        run_started_at,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        run_started_at as detected_at
-    from columns where precise_data_type != precise_pre_data_type
-),
+    -- columns
+    columns_added as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            'column_added' as change_type,
+            'Column Added' as change_type_desc,
+            run_started_at,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            run_started_at as detected_at
+        from columns
+        where
+            column_previous_run_started_at is null
+            and run_started_at > node_first_run_started_at
+    ),
 
-all_changes as (
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from added
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from first_observed
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from removed
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from columns_added
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from columns_first_observed
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from columns_removed
-    union
-    select
-        node_id,
-        command_invocation_id,
-        resource_type,
-        project,
-        resource_name,
-        change_type,
-        change_type_desc,
-        column_name,
-        generic_data_type,
-        generic_pre_data_type,
-        precise_data_type,
-        precise_pre_data_type,
-        detected_at
-    from type_changes
-)
+    columns_first_observed as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            'column_first_observed' as change_type,
+            'Column First Observed' as change_type_desc,
+            run_started_at,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            run_started_at as detected_at
+        from columns
+        where
+            column_previous_run_started_at is null
+            and run_started_at = node_first_run_started_at
+    ),
+
+
+    columns_removed as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            'column_removed' as change_type,
+            'Column Removed' as change_type_desc,
+            run_started_at,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            run_started_at as detected_at
+        from columns
+        where
+            column_next_run_started_at is null
+            and run_started_at < node_most_recent_run_started_at
+    ),
+
+    -- type changes
+    type_changes as (
+        select
+            node_id,
+            command_invocation_id,
+            'column' as resource_type,
+            project,
+            resource_name,
+            'type_changed' as change_type,
+            'Type Changed' as change_type_desc,
+            run_started_at,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            run_started_at as detected_at
+        from columns
+        where generic_data_type != generic_pre_data_type
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            'column' as resource_type,
+            project,
+            resource_name,
+            'precision_changed' as change_type,
+            'Precision Changed' as change_type_desc,
+            run_started_at,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            run_started_at as detected_at
+        from columns
+        where precise_data_type != precise_pre_data_type
+    ),
+
+    all_changes as (
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from added
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from first_observed
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from removed
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from columns_added
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from columns_first_observed
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from columns_removed
+        union distinct
+        select
+            node_id,
+            command_invocation_id,
+            resource_type,
+            project,
+            resource_name,
+            change_type,
+            change_type_desc,
+            column_name,
+            generic_data_type,
+            generic_pre_data_type,
+            precise_data_type,
+            precise_pre_data_type,
+            detected_at
+        from type_changes
+    )
 
 select
     {{ dbt_utils.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
@@ -413,4 +421,3 @@ select
     precise_pre_data_type,
     detected_at
 from all_changes
-

--- a/models/reporting/schema_changes.sql
+++ b/models/reporting/schema_changes.sql
@@ -270,7 +270,7 @@ with
             run_started_at as detected_at
         from columns
         where generic_data_type != generic_pre_data_type
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -306,7 +306,7 @@ with
             precise_pre_data_type,
             detected_at
         from added
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -322,7 +322,7 @@ with
             precise_pre_data_type,
             detected_at
         from first_observed
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -338,7 +338,7 @@ with
             precise_pre_data_type,
             detected_at
         from removed
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -354,7 +354,7 @@ with
             precise_pre_data_type,
             detected_at
         from columns_added
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -370,7 +370,7 @@ with
             precise_pre_data_type,
             detected_at
         from columns_first_observed
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -386,7 +386,7 @@ with
             precise_pre_data_type,
             detected_at
         from columns_removed
-        union distinct
+        union all
         select
             node_id,
             command_invocation_id,
@@ -404,7 +404,7 @@ with
         from type_changes
     )
 
-select
+select distinct
     {{ dbt_utils.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
         as execution_key,
     node_id,


### PR DESCRIPTION
This PR adds some logic and data type improvements. 
- replace union with union all in int_execution
- parse json in dim_column
- simplify case and concat logic in dim_date
- use `array_to_string` for bigquery in dim_model
- use empty string instead of null in schema_changes
- replace bare union..select with union all..select distinct in schema_changes for better cross-db compatibility