### PR TITLE
fix duplicate meta keys

### DIFF
--- a/models/marts/dim_execution.yml
+++ b/models/marts/dim_execution.yml
@@ -84,22 +84,8 @@ models:
           format:
             type: date
             pattern: YYYY-MM-DD HH:mm:ss
-        meta:
-          label: Compile Started At
-          hidden: false
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
       - name: query_completed_at
         description: ''
-        meta:
-          label: Query Completed At
-          hidden: false
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
         meta:
           label: Query Completed At
           hidden: false


### PR DESCRIPTION
This PR fixes duplicate `meta` keys in the `dim_execution` definition file