### PR TITLE
Fix dim_model.is_tested logic

### DIFF
--- a/models/marts/dim_model.sql
+++ b/models/marts/dim_model.sql
@@ -9,6 +9,7 @@ with
             {{ dbt_utils.generate_surrogate_key([
                 'command_invocation_id', 'node_id'
                 ]) }} as model_key,
+            command_invocation_id,
             node_id,
             run_started_at,
             resource_type,
@@ -29,6 +30,7 @@ with
 
     _tests as (
         select
+            command_invocation_id,
             lower(
                 {% if target.type in ('snowflake', 'bigquery') %}
                     array_to_string(depends_on_nodes, '')
@@ -42,16 +44,20 @@ with
     _models as (
         select
             node_id,
+            command_invocation_id,
             model_key,
             {{ dbt.concat(["'%'", 'lower(node_id)', "'%'"]) }} as node_key
         from models
     ),
 
     untested_models as (
-        select distinct models.model_key
+        select
+            models.command_invocation_id,
+            models.node_id
         from _models as models
         left outer join _tests as test
-            on test.depends_on_nodes like models.node_key
+            on models.command_invocation_id = test.command_invocation_id
+                and test.depends_on_nodes like models.node_key
         where test.depends_on_nodes is null
     ),
 
@@ -72,12 +78,17 @@ with
             models.tags,
             models.meta,
             models.description,
-            case when untested_models.model_key is null then 'Yes' else 'No' end
-                as is_tested
+            case
+                when exists (
+                        select 1
+                        from untested_models
+                        where models.node_id = untested_models.node_id
+                            and models.command_invocation_id = untested_models.command_invocation_id
+                    ) then 'No'
+                else 'Yes'
+            end as is_tested
         from models
-        left outer join
-            untested_models
-            on models.model_key = untested_models.model_key
+
     )
 
 select * from final


### PR DESCRIPTION
The current `dim_model.is_tested` logic is very slow, but also is incorrect because it looks for tests from any invocation when it should just look for tests on the current invocation. I've made two changes:
1. Join on command_invocation_id for models to tests
2. Instead of joining on the surrogate key, join on the actual table columns