### PR TITLE
Fix: dim_test syntax

### DIFF
--- a/models/intermediate/int_test.sql
+++ b/models/intermediate/int_test.sql
@@ -24,9 +24,6 @@ select
     column_name as test_column,
     test_combination_of_columns,
     test_column_value,
-    -- null out blank/whitespace before casting: upstream stores a blank (not null) for absent
-    -- values, and safe_cast is a plain cast on some adapters (e.g. Redshift), so cast(' ' as
-    -- int) errors. ltrim/rtrim (not trim) so it stays valid on SQL Server < 2017.
     {{ dbt.safe_cast("nullif(rtrim(ltrim(test_column_min_value)), '')", dbt.type_int()) }} as test_column_min_value,
     {{ dbt.safe_cast("nullif(rtrim(ltrim(test_column_max_value)), '')", dbt.type_int()) }} as test_column_max_value,
     test_relationship_from_model_condition,

--- a/models/intermediate/int_test.sql
+++ b/models/intermediate/int_test.sql
@@ -24,8 +24,11 @@ select
     column_name as test_column,
     test_combination_of_columns,
     test_column_value,
-    {{ dbt.safe_cast('test_column_min_value', dbt.type_int()) }} as test_column_min_value,
-    {{ dbt.safe_cast('test_column_max_value', dbt.type_int()) }} as test_column_max_value,
+    -- null out blank/whitespace before casting: upstream stores a blank (not null) for absent
+    -- values, and safe_cast is a plain cast on some adapters (e.g. Redshift), so cast(' ' as
+    -- int) errors. ltrim/rtrim (not trim) so it stays valid on SQL Server < 2017.
+    {{ dbt.safe_cast("nullif(rtrim(ltrim(test_column_min_value)), '')", dbt.type_int()) }} as test_column_min_value,
+    {{ dbt.safe_cast("nullif(rtrim(ltrim(test_column_max_value)), '')", dbt.type_int()) }} as test_column_max_value,
     test_relationship_from_model_condition,
     test_to_model,
     test_relationship_to_field,

--- a/models/marts/dim_test.sql
+++ b/models/marts/dim_test.sql
@@ -38,29 +38,37 @@ with
     -- one model / one source per test so dim_test stays one row per test;
     -- relationship tests cover two models -- the secondary is kept as test_to_model.
     test_model_map as (
-        select
-            command_invocation_id as map_invocation_id,
-            test_node_id as map_node_id,
-            model_key,
-            row_number() over (
-                partition by command_invocation_id, test_node_id
-                order by is_attached desc, tested_node_id
-            ) as model_rank
-        from {{ ref('dbt_observability_marts', 'int_test_model') }}
-        where tested_resource_type = 'model'
+        select map_invocation_id, map_node_id, model_key
+        from (
+            select
+                command_invocation_id as map_invocation_id,
+                test_node_id as map_node_id,
+                model_key,
+                row_number() over (
+                    partition by command_invocation_id, test_node_id
+                    order by is_attached desc, tested_node_id
+                ) as model_rank
+            from {{ ref('dbt_observability_marts', 'int_test_model') }}
+            where tested_resource_type = 'model'
+        ) ranked_models
+        where model_rank = 1
     ),
 
     test_source_map as (
-        select
-            command_invocation_id as map_invocation_id,
-            test_node_id as map_node_id,
-            source_key,
-            row_number() over (
-                partition by command_invocation_id, test_node_id
-                order by is_attached desc, tested_node_id
-            ) as source_rank
-        from {{ ref('dbt_observability_marts', 'int_test_model') }}
-        where tested_resource_type = 'source'
+        select map_invocation_id, map_node_id, source_key
+        from (
+            select
+                command_invocation_id as map_invocation_id,
+                test_node_id as map_node_id,
+                source_key,
+                row_number() over (
+                    partition by command_invocation_id, test_node_id
+                    order by is_attached desc, tested_node_id
+                ) as source_rank
+            from {{ ref('dbt_observability_marts', 'int_test_model') }}
+            where tested_resource_type = 'source'
+        ) ranked_sources
+        where source_rank = 1
     )
 
 select
@@ -101,8 +109,6 @@ from test
 left outer join test_model_map
     on test.command_invocation_id = test_model_map.map_invocation_id
         and test.node_id = test_model_map.map_node_id
-        and test_model_map.model_rank = 1
 left outer join test_source_map
     on test.command_invocation_id = test_source_map.map_invocation_id
         and test.node_id = test_source_map.map_node_id
-        and test_source_map.source_rank = 1


### PR DESCRIPTION
This PR brings two portability fixes for dim_test:

- min/max cast: absent bounds arrive as a blank, not NULL. cast(blank as int) errors on plain-cast adapters. Guard with nullif(rtrim(ltrim(...)), '') for backwards-compat.
- window-rank join replace with filter rank = 1 inside the CTEs.