### PR TITLE
Fix deprecation warnings for dbt-core.v11

### DIFF
--- a/models/marts/dim_column.yml
+++ b/models/marts/dim_column.yml
@@ -2,75 +2,87 @@ version: 2
 models:
   - name: dim_column
     description: ''
-    meta:
-      label: Column Dimension
-      joins:
-        - to: dim_model
-          type: inner
-          join_on:
-            - from_field: model_key
-              to_field: model_key
+    config:
+      meta:
+        label: Column Dimension
+        joins:
+          - to: dim_model
+            type: inner
+            join_on:
+              - from_field: model_key
+                to_field: model_key
     columns:
-    - name: column_key
-      data_type: text
-      description: ''
-      tests:
-      - not_null
-      - unique
-      meta:
-        label: column_key
-        hidden: true
-      constraints:
-        - type: not_null
-        - type: unique
-        - type: primary_key
-          warn_unenforced: false
-    - name: model_key
-      description: ''
-      meta:
-        hidden: true
-    - name: node_id
-      description: ''
-      data_type: text
-      meta:
-        label: Node ID
-    - name: resource_type
-      description: ''
-      data_type: text
-      meta:
-        label: Resource Type
-    - name: project
-      description: ''
-      data_type: text
-      meta:
-        label: Project
-    - name: resource_name
-      description: ''
-      data_type: text
-      meta:
-        label: Resource Name
-    - name: column_name
-      description: ''
-      data_type: text
-      meta:
-        label: Column Name
-    - name: data_type
-      description: ''
-      data_type: text
-      meta:
-        label: Data Type
-    - name: tags
-      description: ''
-      data_type: text
-      meta:
-        label: Tags
-    - name: meta
-      description: ''
-      data_type: text
-      meta:
-        label: Meta
-    - name: description
-      description: ''
-      data_type: text
-      meta:
-        label: Description
+      - name: column_key
+        data_type: text
+        description: ''
+        tests:
+          - not_null
+          - unique
+        config:
+          meta:
+            label: column_key
+            hidden: true
+        constraints:
+          - type: not_null
+          - type: unique
+          - type: primary_key
+            warn_unenforced: false
+      - name: model_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: resource_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Type
+      - name: project
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Project
+      - name: resource_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Name
+      - name: column_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Column Name
+      - name: data_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Data Type
+      - name: tags
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Tags
+      - name: meta
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Meta
+      - name: description
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Description

--- a/models/marts/dim_date__observability.yml
+++ b/models/marts/dim_date__observability.yml
@@ -3,16 +3,17 @@ models:
   - name: dim_date__observability
     config:
       alias: dim_date
+      meta:
+        label: Date Dimension
     description: ""
-    meta:
-      label: Date Dimension
     columns:
       - name: date_key
         description: ""
         data_type: text
-        meta:
-          label: date_key
-          hidden: true
+        config:
+          meta:
+            label: date_key
+            hidden: true
         tests:
           - not_null
           - unique
@@ -24,94 +25,112 @@ models:
       - name: date_full
         description: ""
         data_type: date
-        meta:
-          label: Date Full
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD
+        config:
+          meta:
+            label: Date Full
+            datatype: date
+            format:
+              type: date
+              pattern: YYYY-MM-DD
       - name: fiscal_year
         description: ""
-        meta:
-          label: Fiscal Year
+        config:
+          meta:
+            label: Fiscal Year
         data_type: integer
       - name: fiscal_quarter
         description: ""
-        meta:
-          label: Fiscal Quarter
+        config:
+          meta:
+            label: Fiscal Quarter
         data_type: integer
       - name: fiscal_month
         description: ""
-        meta:
-          label: Fiscal Month
+        config:
+          meta:
+            label: Fiscal Month
         data_type: integer
       - name: fiscal_month_name
         description: ""
-        meta:
-          label: Fiscal Month Name (Full)
+        config:
+          meta:
+            label: Fiscal Month Name (Full)
         data_type: text
       - name: fiscal_month_abbrev
         description: ""
-        meta:
-          label: Fiscal Month Name (Abbrev)
+        config:
+          meta:
+            label: Fiscal Month Name (Abbrev)
         data_type: text
       - name: calendar_year
         description: ""
-        meta:
-          label: Calendar Year
+        config:
+          meta:
+            label: Calendar Year
         data_type: integer
       - name: calendar_quarter
         description: ""
-        meta:
-          label: Calendar Quarter
+        config:
+          meta:
+            label: Calendar Quarter
         data_type: integer
       - name: calendar_month_nbr
         description: ""
-        meta:
-          label: Calendar Month Number
+        config:
+          meta:
+            label: Calendar Month Number
         data_type: integer
       - name: calendar_month_name
         description: ""
-        meta:
-          label: Calendar Month Name (Full)
+        config:
+          meta:
+            label: Calendar Month Name (Full)
         data_type: text
       - name: calendar_month_abbrev
         description: ""
-        meta:
-          label: Calendar Month Name (Abbrev)
+        config:
+          meta:
+            label: Calendar Month Name (Abbrev)
         data_type: text
       - name: calendar_week_of_year
         description: ""
-        meta:
-          label: Calendar Week of Year
+        config:
+          meta:
+            label: Calendar Week of Year
         data_type: integer
       - name: calendar_day_of_year
         description: ""
-        meta:
-          label: Calendar Day of Year
+        config:
+          meta:
+            label: Calendar Day of Year
         data_type: integer
       - name: day_of_month
         description: ""
-        meta:
-          label: Day of Month
+        config:
+          meta:
+            label: Day of Month
         data_type: integer
       - name: day_of_week
         description: ""
-        meta:
-          label: Day of Week
+        config:
+          meta:
+            label: Day of Week
         data_type: integer
       - name: day_of_week_abbrev
         description: ""
-        meta:
-          label: Day of Week (Abbrev)
+        config:
+          meta:
+            label: Day of Week (Abbrev)
         data_type: text
       - name: month_day_num
         description: ""
-        meta:
-          label: Month Day Number
+        config:
+          meta:
+            label: Month Day Number
         data_type: text
       - name: month_day_desc
         description: ""
-        meta:
-          label: Month Day Description
+        config:
+          meta:
+            label: Month Day Description
         data_type: text

--- a/models/marts/dim_execution.yml
+++ b/models/marts/dim_execution.yml
@@ -2,109 +2,126 @@ version: 2
 models:
   - name: dim_execution
     description: ''
-    meta:
-      label: Execution Dimension
+    config:
+      meta:
+        label: Execution Dimension
     columns:
       - name: execution_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
           - type: unique
           - type: primary_key
             warn_unenforced: false
         tests:
-        - not_null
-        - unique
+          - not_null
+          - unique
       - name: node_id
         description: ''
         data_type: text
-        meta:
-          label: Node ID
+        config:
+          meta:
+            label: Node ID
       - name: resource_type
         description: ''
         data_type: text
-        meta:
-          label: Resource Type
+        config:
+          meta:
+            label: Resource Type
       - name: project
         description: ''
         data_type: text
-        meta:
-          label: Project
+        config:
+          meta:
+            label: Project
       - name: resource_name
         description: ''
         data_type: text
-        meta:
-          label: Resource Name
+        config:
+          meta:
+            label: Resource Name
       - name: status
         description: ''
         data_type: text
-        meta:
-          label: Status
+        config:
+          meta:
+            label: Status
       - name: materialization
         description: ''
         data_type: text
-        meta:
-          label: Materialization
+        config:
+          meta:
+            label: Materialization
       - name: schema_name
         description: ''
         data_type: text
-        meta:
-          label: Schema Name
+        config:
+          meta:
+            label: Schema Name
       - name: run_started_at
         description: ''
         data_type: timestamp
-        meta:
-          label: Run Started At
-          hidden: false
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
+        config:
+          meta:
+            label: Run Started At
+            hidden: false
+            datatype: date
+            format:
+              type: date
+              pattern: YYYY-MM-DD HH:mm:ss
       - name: was_full_refresh
         description: ''
         data_type: boolean
-        meta:
-          label: Was Full Refresh
-          datatype: boolean
+        config:
+          meta:
+            label: Was Full Refresh
+            datatype: boolean
       - name: thread_id
         description: ''
         data_type: integer
-        meta:
-          label: Thread ID
-          datatype: integer
+        config:
+          meta:
+            label: Thread ID
+            datatype: integer
       - name: compile_started_at
         description: ''
-        meta:
-          label: Compile Started At
-          hidden: false
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
+        config:
+          meta:
+            label: Compile Started At
+            hidden: false
+            datatype: date
+            format:
+              type: date
+              pattern: YYYY-MM-DD HH:mm:ss
       - name: query_completed_at
         description: ''
-        meta:
-          label: Query Completed At
-          hidden: false
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
+        config:
+          meta:
+            label: Query Completed At
+            hidden: false
+            datatype: date
+            format:
+              type: date
+              pattern: YYYY-MM-DD HH:mm:ss
       - name: most_recent_run
         description: 'Use dim_invocation.most_recent_run instead'
         data_type: text
-        meta:
-          label: Most Recent Run
+        config:
+          meta:
+            label: Most Recent Run
       - name: most_recent_node_run
         description: '"Yes" if this is the most recent run for the node, otherwise "No"'
         data_type: text
-        meta:
-          label: Most Recent Node Run
+        config:
+          meta:
+            label: Most Recent Node Run
       - name: most_recent_node_run_per_day
         description: '"Yes" if this is the most recent run for the node on that day, otherwise "No"'
         data_type: text
-        meta:
-          label: Most Recent Node Run Per Day
+        config:
+          meta:
+            label: Most Recent Node Run Per Day

--- a/models/marts/dim_exposure.yml
+++ b/models/marts/dim_exposure.yml
@@ -1,79 +1,94 @@
 version: 2
 models:
-- name: dim_exposure
-  description: ''
-  meta:
-    label: Exposure Dimension
-  columns:
-  - name: exposure_key
+  - name: dim_exposure
     description: ''
-    meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: type
-    description: ''
-    data_type: text
-    meta:
-      label: Type
-  - name: owner
-    description: ''
-    data_type: text
-    meta:
-      label: Owner
-  - name: maturity
-    description: ''
-    data_type: text
-    meta:
-      label: Maturity
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
-  - name: url
-    description: ''
-    data_type: text
-    meta:
-      label: URL
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
+    config:
+      meta:
+        label: Exposure Dimension
+    columns:
+      - name: exposure_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+        tests:
+          - not_null
+          - unique
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: resource_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Type
+      - name: project
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Project
+      - name: resource_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Name
+      - name: name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Name
+      - name: type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Type
+      - name: owner
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Owner
+      - name: maturity
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Maturity
+      - name: path
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Path
+      - name: description
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Description
+      - name: url
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: URL
+      - name: package_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Package Name
+      - name: depends_on_nodes
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Depends On Nodes

--- a/models/marts/dim_invocation.yml
+++ b/models/marts/dim_invocation.yml
@@ -2,121 +2,145 @@ version: 2
 models:
   - name: dim_invocation
     description: ''
-    meta:
-      label: Invocation Dimension
+    config:
+      meta:
+        label: Invocation Dimension
     columns:
       - name: invocation_key
         description: ''
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         tests:
-        - not_null
-        - unique
+          - not_null
+          - unique
       - name: command_invocation_id
         description: ''
-        meta:
-          label: Command Invocation ID
+        config:
+          meta:
+            label: Command Invocation ID
       - name: run_started_at
         description: ''
-        meta:
-          label: Run Started At
-          datatype: date
-          format:
-            type: date
-            pattern: YYYY-MM-DD HH:mm:ss
+        config:
+          meta:
+            label: Run Started At
+            datatype: date
+            format:
+              type: date
+              pattern: YYYY-MM-DD HH:mm:ss
       - name: invocation_rank
         description: 'Invocation order for all time, where 1 is the most recent invocation'
-        meta:
-          label: Invocation Order
+        config:
+          meta:
+            label: Invocation Order
       - name: most_recent_run
         description: '"Yes" if this is the most recent invocation for all time, partitioned by project, otherwise "No"'
-        meta:
-          label: Most Recent Run
+        config:
+          meta:
+            label: Most Recent Run
       - name: invocation_rank_per_day
         description: 'Invocation order for run date, where 1 is the most recent invocation for that day'
-        meta:
-          label: Invocation Order Per Day
+        config:
+          meta:
+            label: Invocation Order Per Day
       - name: most_recent_run_per_day
         description: '"Yes" if this is the most recent invocation for that day, otherwise "No"'
-        meta:
-          label: Most Recent Run Per Day
+        config:
+          meta:
+            label: Most Recent Run Per Day
       - name: dbt_version
         description: ''
         data_type: text
-        meta:
-          label: dbt Version
+        config:
+          meta:
+            label: dbt Version
       - name: project_name
         description: ''
         data_type: text
-        meta:
-          label: Project Name
+        config:
+          meta:
+            label: Project Name
       - name: dbt_command
         description: ''
         data_type: text
-        meta:
-          label: dbt Command
+        config:
+          meta:
+            label: dbt Command
       - name: full_refresh_flag
         description: ''
         data_type: text
-        meta:
-          label: Full Refresh Flag
+        config:
+          meta:
+            label: Full Refresh Flag
       - name: target_type
         description: ''
         data_type: text
-        meta:
-          label: Target Type
+        config:
+          meta:
+            label: Target Type
       - name: target_profile_name
         description: ''
         data_type: text
-        meta:
-          label: Target Profile Name
+        config:
+          meta:
+            label: Target Profile Name
       - name: target_name
         description: ''
         data_type: text
-        meta:
-          label: Target Name
+        config:
+          meta:
+            label: Target Name
       - name: target_schema
         description: ''
         data_type: text
-        meta:
-          label: Target Schema
+        config:
+          meta:
+            label: Target Schema
       - name: target_threads
         description: ''
         data_type: int
-        meta:
-          label: Target Threads
+        config:
+          meta:
+            label: Target Threads
       - name: dbt_cloud_project_id
         description: ''
         data_type: text
-        meta:
-          label: dbt Cloud Project ID
+        config:
+          meta:
+            label: dbt Cloud Project ID
       - name: dbt_cloud_job_id
         description: ''
         data_type: text
-        meta:
-          label: dbt Cloud Job ID
+        config:
+          meta:
+            label: dbt Cloud Job ID
       - name: dbt_cloud_run_id
         description: ''
         data_type: text
-        meta:
-          label: dbt Cloud Run ID
+        config:
+          meta:
+            label: dbt Cloud Run ID
       - name: dbt_cloud_run_reason_category
         description: ''
         data_type: text
-        meta:
-          label: dbt Cloud Run Reason Category
+        config:
+          meta:
+            label: dbt Cloud Run Reason Category
       - name: dbt_cloud_run_reason
         description: ''
         data_type: text
-        meta:
-          label: dbt Cloud Run Reason
+        config:
+          meta:
+            label: dbt Cloud Run Reason
       - name: env_vars
         description: ''
         data_type: text
-        meta:
-          label: Environment Variables
+        config:
+          meta:
+            label: Environment Variables
       - name: dbt_vars
         description: ''
         data_type: text
-        meta:
-          label: dbt Variables
+        config:
+          meta:
+            label: dbt Variables

--- a/models/marts/dim_metric.yml
+++ b/models/marts/dim_metric.yml
@@ -1,17 +1,19 @@
 version: 2
 models:
-- name: dim_metric
-  description: ''
-  meta:
-    label: Metric Dimension
-  columns:
-  - name: metric_key
+  - name: dim_metric
     description: ''
-    meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
+    config:
+      meta:
+        label: Metric Dimension
+    columns:
+      - name: metric_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+        tests:
+          - not_null
+          - unique
   # - name: resource_type
   #   description: ''
   #   data_type: text
@@ -27,68 +29,81 @@ models:
   #   data_type: text
   #   meta:
   #     label: Resource Name
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: label
-    description: ''
-    data_type: text
-    meta:
-      label: Label
-  - name: model
-    description: ''
-    data_type: text
-    meta:
-      label: Model
-  - name: expression
-    description: ''
-    data_type: text
-    meta:
-      label: Expression
-  - name: calculation_method
-    description: ''
-    data_type: text
-    meta:
-      label: Calculation Method
-  - name: filters
-    description: ''
-    data_type: text
-    meta:
-      label: Filters
-  - name: time_grains
-    description: ''
-    data_type: text
-    meta:
-      label: Time Grains
-  - name: dimensions
-    description: ''
-    data_type: text
-    meta:
-      label: Dimensions
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: meta
-    description: ''
-    data_type: text
-    meta:
-      label: Meta
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Name
+      - name: label
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Label
+      - name: model
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Model
+      - name: expression
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Expression
+      - name: calculation_method
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Calculation Method
+      - name: filters
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Filters
+      - name: time_grains
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Time Grains
+      - name: dimensions
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Dimensions
+      - name: package_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Package Name
+      - name: meta
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Meta
+      - name: depends_on_nodes
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Depends On Nodes
+      - name: description
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Description

--- a/models/marts/dim_model.yml
+++ b/models/marts/dim_model.yml
@@ -2,88 +2,105 @@ version: 2
 models:
   - name: dim_model
     description: ''
-    meta:
-      label: Model Dimension
+    config:
+      meta:
+        label: Model Dimension
     columns:
       - name: model_key
         description: ''
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         tests:
           - not_null
           - unique
       - name: node_id
         description: ''
         data_type: text
-        meta:
-          label: Node ID
+        config:
+          meta:
+            label: Node ID
       - name: resource_type
         description: ''
         data_type: text
-        meta:
-          label: Resource Type
+        config:
+          meta:
+            label: Resource Type
       - name: project
         description: ''
         data_type: text
-        meta:
-          label: Project
+        config:
+          meta:
+            label: Project
       - name: resource_name
         description: ''
         data_type: text
-        meta:
-          label: Resource Name
+        config:
+          meta:
+            label: Resource Name
       - name: database_name
         description: ''
         data_type: text
-        meta:
-          label: Database Name
+        config:
+          meta:
+            label: Database Name
       - name: schema_name
         description: ''
         data_type: text
-        meta:
-          label: Schema Name
+        config:
+          meta:
+            label: Schema Name
       - name: name
         description: ''
         data_type: text
-        meta:
-          label: Name
+        config:
+          meta:
+            label: Name
       - name: package_name
         description: ''
         data_type: text
-        meta:
-          label: Package Name
+        config:
+          meta:
+            label: Package Name
       - name: path
         description: ''
         data_type: text
-        meta:
-          label: Path
+        config:
+          meta:
+            label: Path
       - name: checksum
         description: ''
         data_type: text
-        meta:
-          label: Checksum
+        config:
+          meta:
+            label: Checksum
       - name: materialization
         description: ''
         data_type: text
-        meta:
-          label: Materialization
+        config:
+          meta:
+            label: Materialization
       - name: tags
         description: ''
         data_type: text
-        meta:
-          label: Tags
+        config:
+          meta:
+            label: Tags
       - name: meta
         description: ''
         data_type: text
-        meta:
-          label: Meta
+        config:
+          meta:
+            label: Meta
       - name: description
         description: ''
         data_type: text
-        meta:
-          label: Description
+        config:
+          meta:
+            label: Description
       - name: is_tested
         description: ''
         data_type: text
-        meta:
-          label: Model Is Tested
+        config:
+          meta:
+            label: Model Is Tested

--- a/models/marts/dim_seed.yml
+++ b/models/marts/dim_seed.yml
@@ -1,64 +1,76 @@
 version: 2
 models:
-- name: dim_seed
-  description: ''
-  meta:
-    label: Seed Dimension
-  columns:
-  - name: seed_key
+  - name: dim_seed
     description: ''
-    meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: checksum
-    description: ''
-    data_type: text
-    meta:
-      label: Checksum
+    config:
+      meta:
+        label: Seed Dimension
+    columns:
+      - name: seed_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+        tests:
+          - not_null
+          - unique
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: resource_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Type
+      - name: project
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Project
+      - name: resource_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Name
+      - name: database_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Database Name
+      - name: schema_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Schema Name
+      - name: name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Name
+      - name: package_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Package Name
+      - name: path
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Path
+      - name: checksum
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Checksum

--- a/models/marts/dim_snapshot.yml
+++ b/models/marts/dim_snapshot.yml
@@ -1,74 +1,88 @@
 version: 2
 models:
-- name: dim_snapshot
-  description: ''
-  meta:
-    label: Snapshot Dimension
-  columns:
-  - name: snapshot_key
+  - name: dim_snapshot
     description: ''
-    meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: checksum
-    description: ''
-    data_type: text
-    meta:
-      label: Checksum
-  - name: strategy
-    description: ''
-    data_type: text
-    meta:
-      label: Strategy
+    config:
+      meta:
+        label: Snapshot Dimension
+    columns:
+      - name: snapshot_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+        tests:
+          - not_null
+          - unique
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: resource_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Type
+      - name: project
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Project
+      - name: resource_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Name
+      - name: database_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Database Name
+      - name: schema_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Schema Name
+      - name: name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Name
+      - name: depends_on_nodes
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Depends On Nodes
+      - name: package_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Package Name
+      - name: path
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Path
+      - name: checksum
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Checksum
+      - name: strategy
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Strategy

--- a/models/marts/dim_source.yml
+++ b/models/marts/dim_source.yml
@@ -2,78 +2,93 @@ version: 2
 models:
   - name: dim_source
     description: ''
-    meta:
-      label: Source Dimension
+    config:
+      meta:
+        label: Source Dimension
     columns:
       - name: source_key
         description: ''
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         tests:
           - not_null
           - unique
       - name: node_id
         description: ''
         data_type: text
-        meta:
-          label: Node ID
+        config:
+          meta:
+            label: Node ID
       - name: resource_type
         description: ''
         data_type: text
-        meta:
-          label: Resource Type
+        config:
+          meta:
+            label: Resource Type
       - name: project
         description: ''
         data_type: text
-        meta:
-          label: Project
+        config:
+          meta:
+            label: Project
       - name: resource_name
         description: ''
         data_type: text
-        meta:
-          label: Resource Name
+        config:
+          meta:
+            label: Resource Name
       - name: database_name
         description: ''
         data_type: text
-        meta:
-          label: Database Name
+        config:
+          meta:
+            label: Database Name
       - name: schema_name
         description: ''
         data_type: text
-        meta:
-          label: Schema Name
+        config:
+          meta:
+            label: Schema Name
       - name: source_name
         description: ''
         data_type: text
-        meta:
-          label: Source Name
+        config:
+          meta:
+            label: Source Name
       - name: loader
         description: ''
         data_type: text
-        meta:
-          label: Loader
+        config:
+          meta:
+            label: Loader
       - name: name
         description: ''
         data_type: text
-        meta:
-          label: Name
+        config:
+          meta:
+            label: Name
       - name: identifier
         description: ''
         data_type: text
-        meta:
-          label: Identifier
+        config:
+          meta:
+            label: Identifier
       - name: loaded_at_field
         description: ''
         data_type: text
-        meta:
-          label: Loaded At Field
+        config:
+          meta:
+            label: Loaded At Field
       - name: freshness
         description: ''
         data_type: text
-        meta:
-          label: Freshness
+        config:
+          meta:
+            label: Freshness
       - name: is_tested
         description: ''
         data_type: text
-        meta:
-          label: Source Is Tested
+        config:
+          meta:
+            label: Source Is Tested

--- a/models/marts/dim_test.yml
+++ b/models/marts/dim_test.yml
@@ -1,157 +1,188 @@
 version: 2
 models:
-- name: dim_test
-  description: ''
-  meta:
-    label: Test Dimension
-  columns:
-  - name: test_key
+  - name: dim_test
     description: ''
-    meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: invocation_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-  - name: model_key
-    description: 'Foreign key to dim_model for the model this test covers (primary model for relationship tests)'
-    data_type: text
-    meta:
-      hidden: true
-    tests:
-    - relationships:
-        to: ref('dim_model')
-        field: model_key
-  - name: source_key
-    description: 'Foreign key to dim_source for the source this test covers (null for model-targeted tests)'
-    data_type: text
-    meta:
-      hidden: true
-    tests:
-    - relationships:
-        to: ref('dim_source')
-        field: source_key
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: test_path
-    description: ''
-    data_type: text
-    meta:
-      label: Test Path
-  - name: test_layer
-    description: 'Second segment of test_path (e.g. the model layer the test lives under)'
-    data_type: text
-    meta:
-      label: Test Layer
-  - name: tags
-    description: ''
-    data_type: text
-    meta:
-      label: Tags
-  - name: test_metadata
-    description: ''
-    data_type: text
-    meta:
-      label: Test Metadata
-  - name: test_package
-    description: 'Package namespace the generic test comes from (test_metadata.namespace)'
-    data_type: text
-    meta:
-      label: Test Package
-  - name: test_name
-    description: 'Generic test type, e.g. not_null, unique, relationships (test_metadata.name)'
-    data_type: text
-    meta:
-      label: Test Name
-  - name: test_model
-    description: 'Raw ref()/source() expression the test is attached to (test_metadata.kwargs.model)'
-    data_type: text
-    meta:
-      label: Test Model
-  - name: test_column
-    description: 'Column under test, from the manifest first-class column_name (parsed upstream by dbt_observability). Null for model-level and singular tests.'
-    data_type: text
-    meta:
-      label: Test Column
-  - name: test_combination_of_columns
-    description: 'Comma-separated columns for composite tests, e.g. unique_combination_of_columns (test_metadata.kwargs.combination_of_columns)'
-    data_type: text
-    meta:
-      label: Test Combination Of Columns
-  - name: test_column_value
-    description: 'Expected value for accepted_values-style tests (test_metadata.kwargs.value)'
-    data_type: text
-    meta:
-      label: Test Column Value
-  - name: test_column_min_value
-    description: 'Minimum bound for range tests (test_metadata.kwargs.min_value)'
-    data_type: integer
-    meta:
-      label: Test Column Min Value
-  - name: test_column_max_value
-    description: 'Maximum bound for range tests (test_metadata.kwargs.max_value)'
-    data_type: integer
-    meta:
-      label: Test Column Max Value
-  - name: test_relationship_from_model_condition
-    description: 'from_condition filter on a relationships test (test_metadata.kwargs.from_condition)'
-    data_type: text
-    meta:
-      label: Test Relationship From Model Condition
-  - name: test_to_model
-    description: 'Target model of a relationships test (test_metadata.kwargs.to / compare_model)'
-    data_type: text
-    meta:
-      label: Test To Model
-  - name: test_relationship_to_field
-    description: 'Target field of a relationships test (test_metadata.kwargs.field)'
-    data_type: text
-    meta:
-      label: Test Relationship To Field
-  - name: test_relationship_to_model_condition
-    description: 'to_condition filter on a relationships test (test_metadata.kwargs.to_condition)'
-    data_type: text
-    meta:
-      label: Test Relationship To Model Condition
-  - name: test_column_expression
-    description: 'Expression for expression-style tests (test_metadata.kwargs.expression)'
-    data_type: text
-    meta:
-      label: Test Column Expression
+    config:
+      meta:
+        label: Test Dimension
+    columns:
+      - name: test_key
+        description: ''
+        config:
+          meta:
+            hidden: true
+        tests:
+          - not_null
+          - unique
+      - name: invocation_key
+        description: ''
+        data_type: text
+        config:
+          meta:
+            hidden: true
+      - name: model_key
+        description: 'Foreign key to dim_model for the model this test covers (primary model for relationship tests)'
+        data_type: text
+        config:
+          meta:
+            hidden: true
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_model')
+                field: model_key
+      - name: source_key
+        description: 'Foreign key to dim_source for the source this test covers (null for model-targeted tests)'
+        data_type: text
+        config:
+          meta:
+            hidden: true
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_source')
+                field: source_key
+      - name: node_id
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Node ID
+      - name: resource_type
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Type
+      - name: project
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Project
+      - name: resource_name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Resource Name
+      - name: name
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Name
+      - name: description
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Description
+      - name: depends_on_nodes
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Depends On Nodes
+      - name: test_path
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Test Path
+      - name: test_layer
+        description: 'Second segment of test_path (e.g. the model layer the test lives under)'
+        data_type: text
+        config:
+          meta:
+            label: Test Layer
+      - name: tags
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Tags
+      - name: test_metadata
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Test Metadata
+      - name: test_package
+        description: 'Package namespace the generic test comes from (test_metadata.namespace)'
+        data_type: text
+        config:
+          meta:
+            label: Test Package
+      - name: test_name
+        description: 'Generic test type, e.g. not_null, unique, relationships (test_metadata.name)'
+        data_type: text
+        config:
+          meta:
+            label: Test Name
+      - name: test_model
+        description: 'Raw ref()/source() expression the test is attached to (test_metadata.kwargs.model)'
+        data_type: text
+        config:
+          meta:
+            label: Test Model
+      - name: test_column
+        description: 'Column under test, from the manifest first-class column_name (parsed upstream by dbt_observability). Null for model-level and singular tests.'
+        data_type: text
+        config:
+          meta:
+            label: Test Column
+      - name: test_combination_of_columns
+        description: 'Comma-separated columns for composite tests, e.g. unique_combination_of_columns (test_metadata.kwargs.combination_of_columns)'
+        data_type: text
+        config:
+          meta:
+            label: Test Combination Of Columns
+      - name: test_column_value
+        description: 'Expected value for accepted_values-style tests (test_metadata.kwargs.value)'
+        data_type: text
+        config:
+          meta:
+            label: Test Column Value
+      - name: test_column_min_value
+        description: 'Minimum bound for range tests (test_metadata.kwargs.min_value)'
+        data_type: integer
+        config:
+          meta:
+            label: Test Column Min Value
+      - name: test_column_max_value
+        description: 'Maximum bound for range tests (test_metadata.kwargs.max_value)'
+        data_type: integer
+        config:
+          meta:
+            label: Test Column Max Value
+      - name: test_relationship_from_model_condition
+        description: 'from_condition filter on a relationships test (test_metadata.kwargs.from_condition)'
+        data_type: text
+        config:
+          meta:
+            label: Test Relationship From Model Condition
+      - name: test_to_model
+        description: 'Target model of a relationships test (test_metadata.kwargs.to / compare_model)'
+        data_type: text
+        config:
+          meta:
+            label: Test To Model
+      - name: test_relationship_to_field
+        description: 'Target field of a relationships test (test_metadata.kwargs.field)'
+        data_type: text
+        config:
+          meta:
+            label: Test Relationship To Field
+      - name: test_relationship_to_model_condition
+        description: 'to_condition filter on a relationships test (test_metadata.kwargs.to_condition)'
+        data_type: text
+        config:
+          meta:
+            label: Test Relationship To Model Condition
+      - name: test_column_expression
+        description: 'Expression for expression-style tests (test_metadata.kwargs.expression)'
+        data_type: text
+        config:
+          meta:
+            label: Test Column Expression

--- a/models/marts/fact_column.yml
+++ b/models/marts/fact_column.yml
@@ -1,109 +1,124 @@
 version: 2
 models:
-- name: fact_column
-  description: ''
-  meta:
-    label: Column Fact
-    joins:
-      - to: dim_column
-        type: inner
-        join_on:
-          - from_field: column_key
-            exp: '='
-            to_field: column_key
-      - to: dim_execution
-        type: inner
-        join_on:
-          - from_field: execution_key
-            exp: '='
-            to_field: execution_key
-  columns:
-  - name: column_key
-    data_type: text
-    meta:
-      hidden: true
-      datatype: text
-    constraints:
-      - type: not_null
-      - type: primary_key
-        warn_unenforced: false
-    tests:
-      - not_null
-      - unique
-      - relationships:
-          to: ref('dim_column')
-          field: column_key
-  - name: execution_key
+  - name: fact_column
     description: ''
-    data_type: text
-    meta:
-      hidden: true
-      datatype: text
-    constraints:
-      - type: not_null
-  - name: is_documented
-    description: ''
-    data_type: boolean
-    meta:
-      label: Is Documented
-      datatype: boolean
-  - name: row_count
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Count
-      datatype: bigint
-  - name: row_distinct
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Distinct
-      datatype: bigint
-  - name: row_null
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Null
-      datatype: bigint
-  - name: row_min
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Min
-      datatype: number
-  - name: row_max
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Max
-      datatype: number
-  - name: row_avg
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Avg
-      datatype: number
-  - name: row_sum
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Sum
-      datatype: number
-  - name: row_stdev
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Stdev
-      datatype: number
-  - name: is_metric
-    description: ''
-    data_type: boolean
-    meta:
-      label: Is Metric
-      datatype: boolean
-  - name: column_values
-    description: ''
-    data_type: text
-    meta:
-      label: Column Values
-      datatype: text
+    config:
+      meta:
+        label: Column Fact
+        joins:
+          - to: dim_column
+            type: inner
+            join_on:
+              - from_field: column_key
+                exp: '='
+                to_field: column_key
+          - to: dim_execution
+            type: inner
+            join_on:
+              - from_field: execution_key
+                exp: '='
+                to_field: execution_key
+    columns:
+      - name: column_key
+        data_type: text
+        config:
+          meta:
+            hidden: true
+            datatype: text
+        constraints:
+          - type: not_null
+          - type: primary_key
+            warn_unenforced: false
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('dim_column')
+                field: column_key
+      - name: execution_key
+        description: ''
+        data_type: text
+        config:
+          meta:
+            hidden: true
+            datatype: text
+        constraints:
+          - type: not_null
+      - name: is_documented
+        description: ''
+        data_type: boolean
+        config:
+          meta:
+            label: Is Documented
+            datatype: boolean
+      - name: row_count
+        description: ''
+        data_type: bigint
+        config:
+          meta:
+            label: Row Count
+            datatype: bigint
+      - name: row_distinct
+        description: ''
+        data_type: bigint
+        config:
+          meta:
+            label: Row Distinct
+            datatype: bigint
+      - name: row_null
+        description: ''
+        data_type: bigint
+        config:
+          meta:
+            label: Row Null
+            datatype: bigint
+      - name: row_min
+        description: ''
+        data_type: numeric
+        config:
+          meta:
+            label: Row Min
+            datatype: number
+      - name: row_max
+        description: ''
+        data_type: numeric
+        config:
+          meta:
+            label: Row Max
+            datatype: number
+      - name: row_avg
+        description: ''
+        data_type: numeric
+        config:
+          meta:
+            label: Row Avg
+            datatype: number
+      - name: row_sum
+        description: ''
+        data_type: numeric
+        config:
+          meta:
+            label: Row Sum
+            datatype: number
+      - name: row_stdev
+        description: ''
+        data_type: numeric
+        config:
+          meta:
+            label: Row Stdev
+            datatype: number
+      - name: is_metric
+        description: ''
+        data_type: boolean
+        config:
+          meta:
+            label: Is Metric
+            datatype: boolean
+      - name: column_values
+        description: ''
+        data_type: text
+        config:
+          meta:
+            label: Column Values
+            datatype: text

--- a/models/marts/fact_execution.yml
+++ b/models/marts/fact_execution.yml
@@ -2,358 +2,389 @@ version: 2
 models:
   - name: fact_execution
     description: ''
-    meta:
-      label: Execution Fact
-      display_index: 1
-      joins:
-        - to: dim_execution
-          type: inner
-          join_on:
-            - from_field: execution_key
-              exp: '='
-              to_field: execution_key
-        - to: dim_invocation
-          type: inner
-          join_on:
-            - from_field: invocation_key
-              exp: '='
-              to_field: invocation_key
-        - to: dim_model
-          type: inner
-          join_on:
-            - from_field: model_key
-              exp: '='
-              to_field: model_key
-        - to: dim_test
-          type: inner
-          join_on:
-            - from_field: test_key
-              exp: '='
-              to_field: test_key
-        - to: dim_seed
-          type: inner
-          join_on:
-            - from_field: seed_key
-              exp: '='
-              to_field: seed_key
-        - to: dim_source
-          type: inner
-          join_on:
-            - from_field: source_key
-              exp: '='
-              to_field: source_key
-        - to: dim_snapshot
-          type: inner
-          join_on:
-            - from_field: snapshot_key
-              exp: '='
-              to_field: snapshot_key
-        - to: dim_metric
-          type: inner
-          join_on:
-            - from_field: metric_key
-              exp: '='
-              to_field: metric_key
-        - to: dim_exposure
-          type: inner
-          join_on:
-            - from_field: exposure_key
-              exp: '='
-              to_field: exposure_key
-        - to: dim_date__observability
-          type: inner
-          join_on:
-            - from_field: date_key
-              exp: '='
-              to_field: date_key
+    config:
+      meta:
+        label: Execution Fact
+        display_index: 1
+        joins:
+          - to: dim_execution
+            type: inner
+            join_on:
+              - from_field: execution_key
+                exp: '='
+                to_field: execution_key
+          - to: dim_invocation
+            type: inner
+            join_on:
+              - from_field: invocation_key
+                exp: '='
+                to_field: invocation_key
+          - to: dim_model
+            type: inner
+            join_on:
+              - from_field: model_key
+                exp: '='
+                to_field: model_key
+          - to: dim_test
+            type: inner
+            join_on:
+              - from_field: test_key
+                exp: '='
+                to_field: test_key
+          - to: dim_seed
+            type: inner
+            join_on:
+              - from_field: seed_key
+                exp: '='
+                to_field: seed_key
+          - to: dim_source
+            type: inner
+            join_on:
+              - from_field: source_key
+                exp: '='
+                to_field: source_key
+          - to: dim_snapshot
+            type: inner
+            join_on:
+              - from_field: snapshot_key
+                exp: '='
+                to_field: snapshot_key
+          - to: dim_metric
+            type: inner
+            join_on:
+              - from_field: metric_key
+                exp: '='
+                to_field: metric_key
+          - to: dim_exposure
+            type: inner
+            join_on:
+              - from_field: exposure_key
+                exp: '='
+                to_field: exposure_key
+          - to: dim_date__observability
+            type: inner
+            join_on:
+              - from_field: date_key
+                exp: '='
+                to_field: date_key
     columns:
       - name: execution_key
         description: ''
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         tests:
           - not_null
           - unique
       - name: invocation_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: model_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: test_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: seed_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: source_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: snapshot_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: metric_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: exposure_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: node_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: date_key
         description: ''
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
         constraints:
           - type: not_null
       - name: status
         description: 'Execution result status (e.g. pass, fail, error, warn, success)'
         data_type: text
-        meta:
-          label: Status
+        config:
+          meta:
+            label: Status
       - name: is_pass
         description: 'Flag (1/0) indicating the node execution passed'
         data_type: numeric
-        meta:
-          metrics:
-            passed:
-              sql: "${is_pass}"
-              label: Passed
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              passed:
+                sql: "${is_pass}"
+                label: Passed
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: is_failure
         description: 'Flag (1/0) indicating the node execution failed or errored'
         data_type: numeric
-        meta:
-          metrics:
-            failed:
-              sql: "${is_failure}"
-              label: Failed
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              failed:
+                sql: "${is_failure}"
+                label: Failed
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: is_warn
         description: 'Flag (1/0) indicating the node execution returned a warning'
         data_type: numeric
-        meta:
-          metrics:
-            warned:
-              sql: "${is_warn}"
-              label: Warned
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              warned:
+                sql: "${is_warn}"
+                label: Warned
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: pass_rate
         description: 'Share of node executions that passed'
-        meta:
-          metrics:
-            pass_rate:
-              sql: "${is_pass}"
-              label: Pass Rate
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              pass_rate:
+                sql: "${is_pass}"
+                label: Pass Rate
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"
       - name: total_node_runtime
         description: ''
         data_type: numeric
-        meta:
-          metrics:
-            total_node_runtime:
-              label: Total Node Runtime
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 1
-                suffix: s
+        config:
+          meta:
+            metrics:
+              total_node_runtime:
+                label: Total Node Runtime
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 1
+                  suffix: s
       - name: previous_runtime
         description: ''
         data_type: numeric
-        meta:
-          metrics:
-            previous_runtime:
-              label: Previous Runtime
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 1
-                suffix: s
+        config:
+          meta:
+            metrics:
+              previous_runtime:
+                label: Previous Runtime
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 1
+                  suffix: s
       - name: average_runtime
         description: ''
         data_type: numeric
-        meta:
-          metrics:
-            average_runtime:
-              label: Average Runtime
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 1
-                suffix: s
+        config:
+          meta:
+            metrics:
+              average_runtime:
+                label: Average Runtime
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 1
+                  suffix: s
       - name: total_invocation_runtime
         description: ''
         data_type: numeric
-        meta:
-          metrics:
-            total_invocation_runtime:
-              label: Total Invocation Runtime
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 1
-                suffix: s
+        config:
+          meta:
+            metrics:
+              total_invocation_runtime:
+                label: Total Invocation Runtime
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 1
+                  suffix: s
       - name: runtime_percent_of_total
         description: 'Node runtime as a percent of total invocation runtime'
-        meta:
-          metrics:
-            runtime_percent_of_total:
-              sql: "${total_node_runtime} / ${total_invocation_runtime}"
-              label: "% of Total Invocation Runtime"
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              runtime_percent_of_total:
+                sql: "${total_node_runtime} / ${total_invocation_runtime}"
+                label: "% of Total Invocation Runtime"
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"
       - name: change_from_previous_runtime
         description: 'Percent change from previous runtime'
-        meta:
-          metrics:
-            change_from_previous_runtime:
-              sql: "( ${total_node_runtime} - ${previous_runtime} ) / ${previous_runtime}"
-              label: "% Change (Previous Runtime)"
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              change_from_previous_runtime:
+                sql: "( ${total_node_runtime} - ${previous_runtime} ) / ${previous_runtime}"
+                label: "% Change (Previous Runtime)"
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"
       - name: change_from_average_runtime
         description: 'Percent change from average runtime'
-        meta:
-          metrics:
-            change_from_average_runtime:
-              sql: "( ${total_node_runtime} - ${average_runtime} ) / ${average_runtime}"
-              label: "% Change (Average Runtime)"
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              change_from_average_runtime:
+                sql: "( ${total_node_runtime} - ${average_runtime} ) / ${average_runtime}"
+                label: "% Change (Average Runtime)"
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"
       - name: node_count
         description: "Distinct count of Node ID"
-        meta:
-          metrics:
-            node_count:
-              sql: "${node_key}"
-              label: Node Count
-              type: count_distinct
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              node_count:
+                sql: "${node_key}"
+                label: Node Count
+                type: count_distinct
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: invocation_count
         description: "Distinct count of invocations"
-        meta:
-          metrics:
-            invocation_count:
-              sql: "${invocation_key}"
-              label: Invocation Count
-              type: count_distinct
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              invocation_count:
+                sql: "${invocation_key}"
+                label: Invocation Count
+                type: count_distinct
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: total_rowcount
         description: ''
-        meta:
-          metrics:
-            total_rowcount:
-              label: Total Rowcount
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              total_rowcount:
+                label: Total Rowcount
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: previous_rowcount
         description: ''
-        meta:
-          metrics:
-            previous_rowcount:
-              label: Previous Rowcount
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              previous_rowcount:
+                label: Previous Rowcount
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: average_rowcount
         description: ''
-        meta:
-          metrics:
-            average_rowcount:
-              label: Average Rowcount
-              type: sum
-              format:
-                type: number
-                decimalPlaces: 0
+        config:
+          meta:
+            metrics:
+              average_rowcount:
+                label: Average Rowcount
+                type: sum
+                format:
+                  type: number
+                  decimalPlaces: 0
       - name: change_from_previous_rowcount
         description: 'Percent change from previous rowcount'
-        meta:
-          metrics:
-            change_from_previous_rowcount:
-              sql: "( ${total_rowcount} - ${previous_rowcount} ) / ${previous_rowcount}"
-              label: "% Change (Previous Rowcount)"
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              change_from_previous_rowcount:
+                sql: "( ${total_rowcount} - ${previous_rowcount} ) / ${previous_rowcount}"
+                label: "% Change (Previous Rowcount)"
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"
       - name: change_from_average_rowcount
         description: 'Percent change from average rowcount'
-        meta:
-          metrics:
-            change_from_average_rowcount:
-              sql: "( ${total_rowcount} - ${average_rowcount} ) / ${average_rowcount}"
-              label: "% Change (Average Rowcount)"
-              type: average
-              format:
-                type: percent
-                decimalPlaces: 1
-                suffix: "%"
+        config:
+          meta:
+            metrics:
+              change_from_average_rowcount:
+                sql: "( ${total_rowcount} - ${average_rowcount} ) / ${average_rowcount}"
+                label: "% Change (Average Rowcount)"
+                type: average
+                format:
+                  type: percent
+                  decimalPlaces: 1
+                  suffix: "%"

--- a/models/reporting/schema_changes.yml
+++ b/models/reporting/schema_changes.yml
@@ -2,123 +2,141 @@ version: 2
 models:
   - name: schema_changes
     description: 'Tracks changes made to database schemas over time, including alterations to table structures, column structures, data types, and resource additions or removals'
-    meta:
-      label: Schema Changes
-      display_index: 1
-      joins:
-        - to: dim_execution
-          type: inner
-          join_on:
-            - from_field: execution_key
-              exp: '='
-              to_field: execution_key
+    config:
+      meta:
+        label: Schema Changes
+        display_index: 1
+        joins:
+          - to: dim_execution
+            type: inner
+            join_on:
+              - from_field: execution_key
+                exp: '='
+                to_field: execution_key
     columns:
       - name: execution_key
         description: 'Unique identifier for each execution instance, used to track and join execution metadata.'
         data_type: text
-        meta:
-          hidden: true
+        config:
+          meta:
+            hidden: true
       - name: node_id
         description: 'Unique identifier for a node within the dbt DAG, representing a model or other asset. Takes the form of <resource_type>.<project_name>.<resource_name> (e.g. `model.edw.dim_date`)'
         data_type: text
-        meta:
-          label: Node ID
+        config:
+          meta:
+            label: Node ID
       - name: resource_type
         description: 'The type of resource being modified. Includes model, test, seed, snapshot, source, column'
         data_type: text
-        meta:
-          label: Resource Type
+        config:
+          meta:
+            label: Resource Type
       - name: project
         description: 'The dbt project where the schema change occurred.'
         data_type: text
-        meta:
-          label: Project
+        config:
+          meta:
+            label: Project
       - name: resource_name
         description: 'The name of the resource impacted by the schema change.'
         data_type: text
-        meta:
-          label: Resource Name
+        config:
+          meta:
+            label: Resource Name
       - name: change_type
         description: 'Details the type of schema change that was applied. Includes <resource_type>_added, <resource_type>_removed, type_changed, precision_changed'
         data_type: text
-        meta:
-          label: Change Type
+        config:
+          meta:
+            label: Change Type
       - name: change_type_desc
         description: 'Formatted change_type for reporting'
         data_type: text
-        meta:
-          label: Change Type Description
+        config:
+          meta:
+            label: Change Type Description
       - name: column_name
         description: 'The name of the column affected by the schema change. Will be null for non-column changes (e.g. model added).'
         data_type: text
-        meta:
-          label: Column Name
+        config:
+          meta:
+            label: Column Name
       - name: generic_data_type
         description: 'The general data type of the column after the schema change. Includes Text, Numeric, Boolean, Date/Time, Binary, Spatial, UUID, Json'
         data_type: text
-        meta:
-          label: Generic Data Type
+        config:
+          meta:
+            label: Generic Data Type
       - name: generic_pre_data_type
         description: 'The general data type of the column before the schema change.'
         data_type: text
-        meta:
-          label: Previous Generic Data Type
+        config:
+          meta:
+            label: Previous Generic Data Type
       - name: precise_data_type
         description: 'The exact data type of the column after the schema change (e.g. varchar(255), int4).'
         data_type: text
-        meta:
-          label: Precise Data Type
+        config:
+          meta:
+            label: Precise Data Type
       - name: precise_pre_data_type
         description: 'The exact data type of the column before the schema change.'
         data_type: text
-        meta:
-          label: Previous Precise Data Type
+        config:
+          meta:
+            label: Previous Precise Data Type
       - name: detected_at
         description: 'Timestamp of when the schema change was detected. Based on dbt execution time, not necessarily the exact time the change took place in the repository or project'
         data_type: timestamp
-        meta:
-          label: Detected At
+        config:
+          meta:
+            label: Detected At
       - name: schema_changes
-        meta:
-          metrics:
-            schema_changes:
-              sql: "${node_id}"
-              label: Schema Change Count
-              type: count_distinct
-              format:
-                type: number
-                decimalPlaces: 0
-              description: 'Counts distinct schema changes detected by node ID.'
+        config:
+          meta:
+            metrics:
+              schema_changes:
+                sql: "${node_id}"
+                label: Schema Change Count
+                type: count_distinct
+                format:
+                  type: number
+                  decimalPlaces: 0
+                description: 'Counts distinct schema changes detected by node ID.'
       - name: resource_count
-        meta:
-          metrics:
-            resource_count:
-              sql: "${resource_name}"
-              label: Resource Count
-              type: count_distinct
-              format:
-                type: number
-                decimalPlaces: 0
-              description: 'Counts distinct resources (tables/models) affected by schema changes.'
+        config:
+          meta:
+            metrics:
+              resource_count:
+                sql: "${resource_name}"
+                label: Resource Count
+                type: count_distinct
+                format:
+                  type: number
+                  decimalPlaces: 0
+                description: 'Counts distinct resources (tables/models) affected by schema changes.'
       - name: rowcount
-        meta:
-          metrics:
-            rowcount:
-              sql: "${node_id}"
-              label: Row Count
-              type: count
-              format:
-                type: number
-                decimalPlaces: 0
-              description: 'Counts total rows impacted by schema changes, based on node ID.'
+        config:
+          meta:
+            metrics:
+              rowcount:
+                sql: "${node_id}"
+                label: Row Count
+                type: count
+                format:
+                  type: number
+                  decimalPlaces: 0
+                description: 'Counts total rows impacted by schema changes, based on node ID.'
       - name: column_count
-        meta:
-          metrics:
-            column_count:
-              sql: "${column_name}"
-              label: Column Count
-              type: count
-              format:
-                type: number
-                decimalPlaces: 0
-              description: 'Counts total columns impacted by schema changes.'
+        config:
+          meta:
+            metrics:
+              column_count:
+                sql: "${column_name}"
+                label: Column Count
+                type: count
+                format:
+                  type: number
+                  decimalPlaces: 0
+                description: 'Counts total columns impacted by schema changes.'

--- a/models/staging/staging.yml
+++ b/models/staging/staging.yml
@@ -1,35 +1,46 @@
 version: 2
 models:
   - name: stg_column
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_date
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_execution
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_exposure
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_invocation
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_metric
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_model
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_seed
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_snapshot
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_source
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true
   - name: stg_test
-    meta:
-      hidden: true
+    config:
+      meta:
+        hidden: true


### PR DESCRIPTION
Fix deprecation warnings. See [dbt docs](https://docs.getdbt.com/reference/deprecations?version=1.11&name=Core) on deprecations.

Live `.yml` updated.  Only YAML updates so testing was done via:
```bash
dbt parse  --show-all-deprecations --no-partial-parse
```

Incorrect indentation has also been corrected.

Proposed as a minor upgrade from 3.1.1 to 3.2.0