### PR TITLE
Fix deprecation warnings for dbt-core.v11 - MAJOR upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dbt_packages/
 logs/
 venv/
 package-lock.yml
+.vscode/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 
 name: 'dbt_observability_marts'
 version: '0.0.1'
-
+require-dbt-version: ">=1.11.0"
 profile: 'dbt_observability_marts'
 
 model-paths: ["models"]


### PR DESCRIPTION
Adds ontop of https://github.com/flexanalytics/dbt_observability_marts/pull/45.
> Minor bump was reverted. And this PR will be released as a MAJOR upgrade.
- Add required dbt version
- Proposed major upgrade from 3.1.1 to 4.0.0